### PR TITLE
Improve JavaSourceInfo.analyzeSourceDirectories

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/BazelProject.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/BazelProject.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.idea.blaze.base.model.primitives.TargetName;
 import com.salesforce.bazel.eclipse.core.BazelCore;
+import com.salesforce.bazel.eclipse.core.model.discovery.projects.JavaProjectInfo;
 import com.salesforce.bazel.eclipse.core.projectview.BazelProjectView;
 import com.salesforce.bazel.sdk.model.BazelLabel;
 
@@ -211,6 +212,8 @@ public class BazelProject implements IProjectNature {
     private IProject project;
 
     private BazelModel bazelModel;
+
+    private JavaProjectInfo javaProjectInfo;
 
     /**
      * The default constructor is used by Eclipse when the nature is configured for an {@link IProject}.
@@ -489,6 +492,13 @@ public class BazelProject implements IProjectNature {
     }
 
     /**
+     * @return the javaProjectInfo
+     */
+    public JavaProjectInfo getJavaProjectInfo() {
+        return javaProjectInfo;
+    }
+
+    /**
      * Returns the location of the project.
      * <p>
      * The returned location will be the Bazel workspace root directory f {@link #isWorkspaceProject()} returns
@@ -600,6 +610,14 @@ public class BazelProject implements IProjectNature {
 
     public void setBazelTargets(List<BazelTarget> targets, IProgressMonitor monitor) throws CoreException {
         writeBazeltargetsFile(targets.stream().map(BazelTarget::getTargetName), monitor);
+    }
+
+    /**
+     * @param javaProjectInfo
+     *            the javaProjectInfo to set
+     */
+    public void setJavaProjectInfo(JavaProjectInfo javaProjectInfo) {
+        this.javaProjectInfo = javaProjectInfo;
     }
 
     public void setModel(BazelModel bazelModel) {

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/BaseProvisioningStrategy.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/BaseProvisioningStrategy.java
@@ -680,6 +680,7 @@ public abstract class BaseProvisioningStrategy implements TargetProvisioningStra
         }
 
         analyzeProjectInfo(project, javaInfo, monitor);
+        project.setJavaProjectInfo(javaInfo);
 
         return javaInfo;
     }


### PR DESCRIPTION
Fixes #5 

I suppose that `analyzeSourceDirectories` works in the following way:
- counts the number of all Java files in a Bazel target
- the number of all Java files that are on the target's path
If there is a difference, it creates an error marker
[java-tutorial](https://github.com/snjeza/java-tutorial) includes three Java files:
- Greater.java declared in the greeter target
- ProjectRunner.java declared in the ProjectRunner target
- Runner.java declared in the runner target

Even though all Java files are declared in a target, Bazel Eclipse will create an error marker.
The issue happens because Bazel Eclipse tries to analyze files for each target separately and creates a marker for the greeter and ProjectRunner target.
In this case, the greeter and ProjectRunner target have the same package (com.example) and declare both of the classes.

I have updated `analyzeSourceDirectories` in order to check declared classes after analyzing all targets.
If all Java files are declared in a target, Bazel Eclipse won't create any error markers.

You can test it in the following way:
- import [java-tutorial](https://github.com/snjeza/java-tutorial)
there is no error marker
- add some class to com.example or com.example.cmdline
- call Sync Bazel Project Views
You will see an error marker

cc @guw 
