### PR TITLE
[performance] Import the large project

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/BazelPackage.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/BazelPackage.java
@@ -9,12 +9,14 @@ import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Status;
 
+import com.salesforce.bazel.sdk.command.querylight.Target;
 import com.salesforce.bazel.sdk.model.BazelLabel;
 
 /**
@@ -71,6 +73,7 @@ public final class BazelPackage extends BazelElement<BazelPackageInfo, BazelWork
     private final BazelWorkspace parent;
     private final BazelLabel label;
     private final IPath packagePath;
+    private Map<String, Target> targets;
 
     BazelPackage(BazelWorkspace parent, IPath packagePath) throws NullPointerException, IllegalArgumentException {
         this.packagePath =
@@ -86,8 +89,9 @@ public final class BazelPackage extends BazelElement<BazelPackageInfo, BazelWork
             throw new CoreException(
                     Status.error(format("Package '%s' does not exist in workspace '%s'!", label, parent.getName())));
         }
-
-        var targets = BazelPackageInfo.queryForTargets(this, getCommandExecutor());
+        if (targets == null) {
+            targets = BazelPackageInfo.queryForTargets(this, getCommandExecutor());
+        }
         return new BazelPackageInfo(buildFile, this, targets);
     }
 
@@ -342,6 +346,10 @@ public final class BazelPackage extends BazelElement<BazelPackageInfo, BazelWork
         invalidateInfo();
         // force re-loading of the project info immediately
         getInfo();
+    }
+
+    public void setTargets(Map<String, Target> targets) {
+        this.targets = targets;
     }
 
 }

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/SynchronizeProjectViewJob.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/SynchronizeProjectViewJob.java
@@ -652,7 +652,7 @@ public class SynchronizeProjectViewJob extends WorkspaceJob {
 
             // during synchronization resource changes may occur; however, they are triggered by the synchronization activities
             // therefore we suspend cache invalidation of the model due to resource changes
-            workspace.getModelManager().getResourceChangeProcessor().suspendInvalidationFor(workspace);
+            workspace.getModelManager().getResourceChangeProcessor().suspendInvalidationFor(workspace.getModel());
 
             // trigger loading of the project view
             projectView = workspace.getBazelProjectView();

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/cache/BazelElementInfoCache.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/cache/BazelElementInfoCache.java
@@ -14,6 +14,7 @@
 package com.salesforce.bazel.eclipse.core.model.cache;
 
 import java.util.Collection;
+import java.util.function.Supplier;
 
 import com.salesforce.bazel.eclipse.core.model.BazelElement;
 import com.salesforce.bazel.eclipse.core.model.BazelElementInfo;
@@ -112,4 +113,13 @@ public abstract sealed class BazelElementInfoCache permits CaffeineBasedBazelEle
      *            the element info (must not be <code>null</code>)
      */
     public abstract <I extends BazelElementInfo> I putOrGetCached(BazelElement<I, ?> bazelElement, I info);
+
+    /**
+     * @param <I>
+     * @param bazelElement
+     * @param supplier
+     * @return
+     */
+    public abstract <I extends BazelElementInfo> I putOrGetCached(BazelElement<I, ?> bazelElement,
+            Supplier<I> supplier);
 }

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/cache/CaffeineBasedBazelElementInfoCache.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/cache/CaffeineBasedBazelElementInfoCache.java
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.toList;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map.Entry;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +41,7 @@ public final class CaffeineBasedBazelElementInfoCache extends BazelElementInfoCa
 
     private static final String CACHE_KEY_SEPARATOR = "::";
     private static final String EMPTY_STRING = "";
+
     private final Cache<String, BazelElementInfo> cache;
 
     /**
@@ -159,5 +161,11 @@ public final class CaffeineBasedBazelElementInfoCache extends BazelElementInfoCa
     @Override
     public <I extends BazelElementInfo> I putOrGetCached(BazelElement<I, ?> bazelElement, I info) {
         return (I) cache.get(getStableCacheKey(bazelElement), k -> info);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <I extends BazelElementInfo> I putOrGetCached(BazelElement<I, ?> bazelElement, Supplier<I> supplier) {
+        return (I) cache.get(getStableCacheKey(bazelElement), k -> supplier.get());
     }
 }

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/JvmConfigurator.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/JvmConfigurator.java
@@ -165,7 +165,7 @@ public class JvmConfigurator {
             getPrefix(vmType),
             resolvedJavaHomePath.getFileName().toString(),
             bazelWorkspace.getName());
-        var vm = findVmForNameOrPath(resolvedJavaHomePath, name);
+        var vm = findVmForNameOrPath(resolvedJavaHomePath, name, bazelWorkspace, vmType);
 
         // delete if location or other attributes don't not match
         if ((vm instanceof AbstractVMInstall realVm) && (!vm.getInstallLocation().toPath().equals(resolvedJavaHomePath)
@@ -239,12 +239,18 @@ public class JvmConfigurator {
         }
     }
 
-    private IVMInstall findVmForNameOrPath(java.nio.file.Path javaHome, String name) {
+    private IVMInstall findVmForNameOrPath(java.nio.file.Path javaHome, String name, BazelWorkspace bazelWorkspace,
+            String vmType) {
         var file = javaHome.toFile();
         var types = JavaRuntime.getVMInstallTypes();
         for (IVMInstallType type : types) {
             var installs = type.getVMInstalls();
             for (IVMInstall install : installs) {
+                if (!(install instanceof AbstractVMInstall realVm)
+                        || !bazelWorkspace.getLocation().toString().equals(realVm.getAttribute(VM_ATTR_WORKSPACE))
+                        || !vmType.equals(realVm.getAttribute(VM_ATTR_TYPE))) {
+                    continue;
+                }
                 if ((name != null) && name.equals(install.getName())) {
                     return install;
                 }

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/ProjectPerTargetProvisioningStrategy.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/ProjectPerTargetProvisioningStrategy.java
@@ -332,7 +332,7 @@ public class ProjectPerTargetProvisioningStrategy extends BaseProvisioningStrate
         var projectLocation = getFileSystemMapper().getProjectsArea().append(projectName);
 
         createProjectForElement(projectName, projectLocation, target, monitor);
-        target.rediscoverBazelProject();
+        // target.rediscoverBazelProject();
 
         // this call is no longer expected to fail now (unless we need to poke the element info cache manually here)
         return target.getBazelProject();

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/execution/JobsBasedExecutionService.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/execution/JobsBasedExecutionService.java
@@ -86,7 +86,7 @@ public class JobsBasedExecutionService implements BazelModelCommandExecutionServ
                     throw new CoreException(Status.error("Error executing command: " + e.getMessage(), e));
                 } finally {
                     try {
-                        refreshResources(resourcesToRefresh, monitor);
+                        //refreshResources(resourcesToRefresh, monitor);
                         monitor.done();
                     } finally {
                         pm.done();


### PR DESCRIPTION
Fixes #16 

Steps to test:

- clone https://github.com/snjeza/bazel-ls-demo-project/
- cd bazel-ls-demo-project/large
- build the large project:
```
bazel build //...
```
- add 
```
directories:
#  .  # import everything (remove the dot if this is too much)
  module1496_public
  module0472_public
  module0910
  module0910_public
  module1805_public
  module1805
  
derive_targets_from_directories: true

target_provisioning_strategy: project-per-package
```
to .eclipse/.bazelproject
- add the JVM argumente `-Xmx10G -Xms4g -Declipse.bazel.model.cache.expireAfterAccessSeconds=86400 -Djdk.xml.elementAttributeLimit=0` to Eclipse
- import the project in Eclipse without the PR
- The first time it takes about 25+ minutes to import the project on my machine.
- call Sync Bazel Projects View
- The action now takes 20+ minutes.
- delete all projects
- import the project in Eclipse with the PR
- The first time it takes about 20 seconds to import on my machine.
- call Sync Bazel Projects View
- The action now takes 10 seconds.

 