### PR TITLE
Performance: Skip already processed projects

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/classpath/BazelClasspathContainerRuntimeResolver.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/classpath/BazelClasspathContainerRuntimeResolver.java
@@ -8,6 +8,7 @@ import static java.nio.file.Files.isRegularFile;
 import static java.util.Arrays.stream;
 import static org.eclipse.jdt.launching.JavaRuntime.computeUnresolvedRuntimeClasspath;
 
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -55,7 +56,7 @@ public class BazelClasspathContainerRuntimeResolver
         /**
          * the set of already processed projects to avoid duplicate work
          */
-        private final Set<IProject> processedProjects = new LinkedHashSet<>();
+        private final Set<IProject> processedProjects = new HashSet<>();
 
         public void add(IRuntimeClasspathEntry runtimeClasspathEntry) {
             resolvedClasspath.add(runtimeClasspathEntry);

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/util/trace/StopWatch.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/util/trace/StopWatch.java
@@ -34,6 +34,10 @@ public final class StopWatch {
         void stopped(StopWatch stopWatch);
     }
 
+    public static StopWatch startNewStopWatch() {
+        return new StopWatch().start();
+    }
+
     private final StopCallback stopCallback;
     private volatile long startTimeNanos;
     private volatile long endTimeNanos;
@@ -75,9 +79,12 @@ public final class StopWatch {
 
     /**
      * Sets the start time to the current value of {@link System#nanoTime()}.
+     *
+     * @return this stop watch instance for convenience
      */
-    public void start() {
+    public StopWatch start() {
         startTimeNanos = System.nanoTime();
+        return this;
     }
 
     /**


### PR DESCRIPTION
As part of analysis in this PR it was discovered that a complex build graph can overwhelm the runtime classpath computation as observed in #37.

When a project was already processed there is no need to process is it again. It's classpath was resolved and added already. Thus, we now skip it, avoid re-entering branches which we already processed.