### PR TITLE
feat: Add configurable split-package detection via detect_split_packages setting

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/BaseProvisioningStrategy.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/BaseProvisioningStrategy.java
@@ -127,6 +127,7 @@ public abstract class BaseProvisioningStrategy implements TargetProvisioningStra
     private static final String JRE_SYSTEM_LIBRARY_RUNTIME = "current_java_runtime";
     private static final String JRE_SYSTEM_LIBRARY_EE = "execution_environment";
     private static final String CLASSPATH_DEPTH = "classpath_depth";
+    private static final String DETECT_SPLIT_PACKAGES = "detect_split_packages";
 
     private static final String JAVAC_OPT_ADD_OPENS = "--add-opens";
     private static final String JAVAC_OPT_ADD_EXPORTS = "--add-exports";
@@ -1390,7 +1391,13 @@ public abstract class BaseProvisioningStrategy implements TargetProvisioningStra
      * Calls and returns {@link JavaProjectInfo#analyzeProjectRecommendations(boolean, IProgressMonitor)} with
      * recommended defaults.
      * <p>
-     * Subclasses may override to customize defaults
+     * Subclasses may override to customize defaults.
+     * </p>
+     * <p>
+     * The <code>detect_split_packages</code> setting in <code>target_provisioning_settings</code> can be used to
+     * control whether split-package detection is enabled. When set to <code>false</code>, folders containing more
+     * Java files than declared for a particular target will not be reported as a problem. The default is
+     * <code>true</code>.
      * </p>
      *
      * @param javaInfo
@@ -1403,7 +1410,12 @@ public abstract class BaseProvisioningStrategy implements TargetProvisioningStra
      */
     protected IStatus getProjectRecommendations(JavaProjectInfo javaInfo, IProgressMonitor monitor)
             throws CoreException {
-        return javaInfo.analyzeProjectRecommendations(true, monitor);
+        var detectSplitPackages = Boolean.parseBoolean(
+            getFileSystemMapper().getBazelWorkspace()
+                .getBazelProjectView()
+                .targetProvisioningSettings()
+                .getOrDefault(DETECT_SPLIT_PACKAGES, "true"));
+        return javaInfo.analyzeProjectRecommendations(detectSplitPackages, monitor);
     }
 
     protected String getTargetProvisioningSetting(BazelElement<?, ?> bazelElement, String key, String defaultValue)

--- a/docs/common/projectviews.md
+++ b/docs/common/projectviews.md
@@ -158,6 +158,7 @@ The syntax of each entry is `key=value`, where `key` and `value` are expected st
 * `classpath_depth` A integer indicating the depth of source targets runtime dependencies pulled in to the project model during sync (default is `0`, which pulls in all transitive dependencies in the graph).
 	* Providing a value greater then 0 will filter transitive dependencies and provide a partial classpath to the project model.
 	* Note: While all required compile-time dependencies are added regardless, there may be edge cases with the Eclipse compiler which may result in compile errors.
+* `detect_split_packages` (possible values: `true` (default) and `false`; when set to `false`, the IDE will not report warnings for folders containing more Java files than declared in a particular target's `srcs`. This is useful for monorepo setups where multiple Bazel targets share the same source directory hierarchy. Note: this setting has no effect on the `project-per-package` strategy, which never performs split-package detection.)
 
 ### `target_discovery_settings`
 


### PR DESCRIPTION
Allow users to disable split-package warnings through a new `detect_split_packages` target provisioning setting (default: true).

This is useful for monorepo projects where multiple targets share source directories and restructuring is not feasible.

- Add DETECT_SPLIT_PACKAGES constant in BaseProvisioningStrategy
- Read configuration with default value "true"
- Update projectviews.md documentation