### PR TITLE
fix(vscode): lower vscode engine to ^1.105.0 and drop unused velocity bundle

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -10,7 +10,7 @@
 	"preview": true,
 	"engines": {
 		"node": "^22.20.0",
-		"vscode": "^1.106.0"
+		"vscode": "^1.105.0"
 	},
 	"repository": {
 		"type": "git",
@@ -40,7 +40,6 @@
 		"javaExtensions": [
 			"./server/org.eclipse.equinox.event.jar",
 			"./server/com.github.ben-manes.caffeine.jar",
-			"./server/org.apache.velocity.engine-core.jar",
 			"./server/org.jsr-305.jar",
 			"./server/org.fusesource.jansi.jar",
 			"./server/com.google.protobuf.jar",


### PR DESCRIPTION
Two small fixes to `vscode/package.json`.

**1. Lower the VS Code engine floor to `^1.105.0`.**
`^1.106.0` stops the extension installing on editors still on 1.105 — notably Cursor, which runs VS Code 1.105.1. The floor doesn't need to be that high: the extension is typed against `@types/vscode ^1.80.0`, so it never touches a 1.106 API.

**2. Drop `org.apache.velocity.engine-core.jar` from `javaExtensions`.**
It's a dead reference. The p2 repo has no such bundle, so `scripts/server.mjs` never packages it (the VSIX ships 9 of the 10 listed jars), and nothing in the Salesforce bundles imports Velocity. But `BundleUtils.loadBundles` aborts the whole set if a single jar is missing — so on a clean JDT workspace this one bad entry stops the entire Bazel plugin from loading, and nothing resolves. Removing the line fixes it.